### PR TITLE
Fix typo in Edge README

### DIFF
--- a/Edge/Edge/README.md
+++ b/Edge/Edge/README.md
@@ -27,7 +27,7 @@ The architecture has been dockerized to improve management and deployment effici
 
 ## Usage
 
-In a new terminal outside the docker container open a python terminal runing the following command. 
+In a new terminal outside the docker container open a python terminal running the following command. 
 
 ```
 python3


### PR DESCRIPTION
## Summary
- fix a typo in Edge README under Usage section

## Testing
- `grep -n running Edge/Edge/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68591ce1e828832f9ca4bab46efc1605